### PR TITLE
feat: send X-Spoo-Client header on all spoo.me API requests

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -13,7 +13,7 @@ import type {
   VerifyEmailRequest,
   VerifyEmailResponse,
 } from "@/api/types";
-import { AUTH_ENDPOINTS } from "@/lib/constants";
+import { AUTH_ENDPOINTS, CLIENT_HEADER, CLIENT_HEADER_VALUE } from "@/lib/constants";
 import { accessTokenStorage, refreshTokenStorage } from "@/lib/storage";
 import {
   loginResponseSchema,
@@ -99,7 +99,7 @@ export async function refreshAccessToken(): Promise<boolean> {
   try {
     const res = await fetch(AUTH_ENDPOINTS.deviceRefresh, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", [CLIENT_HEADER]: CLIENT_HEADER_VALUE },
       body: JSON.stringify({ refresh_token: refreshToken }),
       signal: AbortSignal.timeout(10_000),
     });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,5 @@
 import type { ApiErrorResponse } from "@/api/types";
-import { AUTH_ENDPOINTS } from "@/lib/constants";
+import { AUTH_ENDPOINTS, CLIENT_HEADER, CLIENT_HEADER_VALUE } from "@/lib/constants";
 import { ApiError, isOffline, NetworkError } from "@/lib/errors";
 import {
   accessTokenStorage,
@@ -43,7 +43,7 @@ async function refreshAccessToken(): Promise<string | null> {
   try {
     const res = await fetch(AUTH_ENDPOINTS.deviceRefresh, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", [CLIENT_HEADER]: CLIENT_HEADER_VALUE },
       body: JSON.stringify({ refresh_token: refreshToken }),
     });
 
@@ -87,6 +87,9 @@ export async function request<T>(
       }
     }
   }
+
+  // Client attribution header (all request() URLs point at the spoo.me backend)
+  headers[CLIENT_HEADER] = CLIENT_HEADER_VALUE;
 
   // Auth header
   if (!noAuth) {

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -1,5 +1,5 @@
 import type { ExportQuery } from "@/api/types";
-import { API_V1 } from "@/lib/constants";
+import { API_V1, CLIENT_HEADER, CLIENT_HEADER_VALUE } from "@/lib/constants";
 import { isOffline, NetworkError } from "@/lib/errors";
 import { accessTokenStorage, apiKeyStorage, authModeStorage } from "@/lib/storage";
 
@@ -17,7 +17,7 @@ export async function exportStats(query: ExportQuery): Promise<Blob> {
     }
   }
 
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = { [CLIENT_HEADER]: CLIENT_HEADER_VALUE };
   const mode = await authModeStorage.getValue();
   if (mode === "apikey") {
     const key = await apiKeyStorage.getValue();

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -1,6 +1,6 @@
 import { request } from "@/api/client";
 import type { StatsQuery, StatsResponse } from "@/api/types";
-import { API_BASE_URL, API_V1 } from "@/lib/constants";
+import { API_BASE_URL, API_V1, CLIENT_HEADER, CLIENT_HEADER_VALUE } from "@/lib/constants";
 import { ApiError } from "@/lib/errors";
 import { statsResponseSchema } from "@/schemas/api";
 
@@ -50,7 +50,7 @@ export interface V0StatsResponse {
  */
 export async function getStatsV0(shortCode: string, password?: string): Promise<V0StatsResponse> {
   const url = `${API_BASE_URL}/stats/${shortCode}`;
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = { [CLIENT_HEADER]: CLIENT_HEADER_VALUE };
 
   const body = password ? new URLSearchParams({ password }) : undefined;
   if (body) {

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -5,6 +5,8 @@ import {
   ACCESS_TOKEN_TTL_MS,
   API_BASE_URL,
   AUTH_ENDPOINTS,
+  CLIENT_HEADER,
+  CLIENT_HEADER_VALUE,
   HISTORY_MAX_ITEMS,
   QR_BRAND,
   TOKEN_REFRESH_BUFFER_MS,
@@ -139,7 +141,7 @@ async function handleTokenRefresh(): Promise<void> {
 async function exchangeDeviceCode(code: string): Promise<void> {
   const res = await fetch(AUTH_ENDPOINTS.deviceToken, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", [CLIENT_HEADER]: CLIENT_HEADER_VALUE },
     body: JSON.stringify({ code }),
   });
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,6 +4,10 @@ export const QR_API_BASE_URL = import.meta.env.VITE_QR_API_BASE_URL || "https://
 export const API_V1 = `${API_BASE_URL}/api/v1`;
 export const QR_API_V1 = `${QR_API_BASE_URL}/api/v1`;
 
+/** Identifies this client to the spoo.me API. Never sent to third-party hosts. */
+export const CLIENT_HEADER = "X-Spoo-Client";
+export const CLIENT_HEADER_VALUE = `snap/${browser.runtime.getManifest().version}`;
+
 export const AUTH_ENDPOINTS = {
   login: `${API_BASE_URL}/auth/login`,
   register: `${API_BASE_URL}/auth/register`,


### PR DESCRIPTION
Every request the extension makes to the spoo.me backend now carries an `X-Spoo-Client: snap/<version>` header (the version comes from the extension manifest, currently `snap/2.0.0`). This lets the API attribute traffic by client.

The header name and value live in `src/lib/constants.ts` and are injected centrally in the api client's `request()` function, plus the few raw `fetch` call sites: device code exchange in the background worker, the two token refresh paths, stats export, and the v0 stats fallback.

The header is only ever sent to `API_BASE_URL` endpoints. QR code image URLs are plain GET image sources, and no third-party host receives the header.

All requests originate from the background service worker or extension pages (popup and side panel), which hold host permissions for spoo.me, so they are exempt from CORS and no server-side header allowance is needed for this to work. The content script makes no network requests.